### PR TITLE
Fixed metadata that enables fonts to be recognised as a family

### DIFF
--- a/src/io/font_export.js
+++ b/src/io/font_export.js
@@ -83,6 +83,11 @@ function createOptionsObject() {
 	options.description = fontSettings.description || ' ';
 	options.copyright = fontSettings.copyright || ' ';
 	options.trademark = fontSettings.trademark || ' ';
+	options.weightClass = parseInt(fontSettings.weight);
+	options.panose = fontSettings.panose.split(' ').map(Number) || [];
+	options.italicAngle = fontSettings.italicAngle || 0;
+	options.slope = fontSettings.slope || 0;
+
 	options.glyphs = [];
 
 	// log('NEW options ARG BEFORE GLYPHS');


### PR DESCRIPTION
I've found out that a few of the fields used by Glyphr Studio were not actually passed on to opentype.js and even it did not use those fields. Some changes were made to enable these to be passed on and be used by the embed copy of opentype.js. Only a couple of fonts were used to test these but changes were recognised by Windows and other apps. Upon further validation of these changes, I recommend pushing them to opentype.js itself.

An issue regarding the fields hhea.caretSlopeRise and hhea.caretSlopeRun for italic and oblique fonts is still pending review but does not prevent font usage or recognition as a family (caret slope had a weird inclination while testing on Word but not on Affinity Designer).