### PR TITLE
add grid guide with snapping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "glyphr-studio-2",
-	"version": "2.9",
+	"version": "2.10",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "glyphr-studio-2",
-			"version": "2.9",
+			"version": "2.10",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@mattlag/xmltojson": "^2.0.2",

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -32,9 +32,9 @@ export class GlyphrStudioApp {
 				overwriteTitle: true, // {bool} Use a 'Dev Mode' window title
 				sampleProject: 'oblegg', // {true/false, 'oblegg', 'bool'} Load the sample project
 				twoSampleProjects: false, // {bool} Load two sample projects
-				currentPage: 'Live preview', // {Sentence case page name} navigate straight to a page
+				currentPage: 'Characters', // {Sentence case page name} navigate straight to a page
 				currentGlyphID: false, // {glyph id} select a glyph
-				currentPanel: false, // {Sentence case panel name} navigate straight to a panel
+				currentPanel: 'Guides', // {Sentence case panel name} navigate straight to a panel
 				currentTool: false, // {Tool name} select a tool
 				stopPageNavigation: false, // {bool} overwrite project-level setting
 				autoSave: false, // {bool} trigger auto saves

--- a/src/app/app_config.json
+++ b/src/app/app_config.json
@@ -1,5 +1,5 @@
 {
   "version": "2.10.3",
-  "versionDate": 1783882800000,
-  "devMode": false
+  "versionDate": 0,
+  "devMode": true
 }

--- a/src/edit_canvas/edit_canvas.js
+++ b/src/edit_canvas/edit_canvas.js
@@ -199,6 +199,7 @@ export class EditCanvas extends HTMLElement {
 				// if (guidesSettings.systemShowGuides) drawSystemGuidelines(!shouldDrawContextCharacters());
 				if (guidesSettings.systemShowGuides) drawSystemGuidelines();
 				if (guidesSettings.customShowGuides) drawCustomGuidelines();
+				if (guidesSettings.gridShow) drawGrid();
 			}
 
 			// Draw glyphs
@@ -251,6 +252,7 @@ export class EditCanvas extends HTMLElement {
 				// if (guidesSettings.systemShowGuides) drawSystemGuidelines(!shouldDrawContextCharacters());
 				if (guidesSettings.systemShowGuides) drawSystemGuidelines();
 				if (guidesSettings.customShowGuides) drawCustomGuidelines();
+				if (guidesSettings.gridShow) drawGrid();
 			}
 
 			const contextCharacterSettings = editor.project.settings.app.contextCharacters;
@@ -448,6 +450,26 @@ export class EditCanvas extends HTMLElement {
 						}
 					}
 				});
+			}
+		}
+
+		function drawGrid() {
+			const gridSquareSize =
+				editor.project.settings.font.upm / editor.project.settings.app.guides.gridDivisions;
+			let x0 = Math.floor(cXsX(0) / gridSquareSize) * gridSquareSize;
+			let x1 = Math.ceil(cXsX(width) / gridSquareSize) * gridSquareSize;
+			let y0 = Math.floor(cYsY(height) / gridSquareSize) * gridSquareSize;
+			let y1 = Math.ceil(cYsY(0) / gridSquareSize) * gridSquareSize;
+
+			setSystemGuideColor(
+				'medium',
+				transparencyToAlpha(editor.project.settings.app.guides.gridTransparency)
+			);
+			for (let x = x0; x <= x1; x += gridSquareSize) {
+				ctx.fillRect(sXcX(x), 0, 1, height);
+			}
+			for (let y = y0; y <= y1; y += gridSquareSize) {
+				ctx.fillRect(0, sYcY(y), width, 1);
 			}
 		}
 

--- a/src/edit_canvas/edit_canvas.js
+++ b/src/edit_canvas/edit_canvas.js
@@ -4,7 +4,7 @@ import { makeElement } from '../common/dom.js';
 import { clone } from '../common/functions.js';
 import { drawGlyph, drawGlyphOutlineMode } from '../display_canvas/draw_paths.js';
 import { kernGroupSideMaxWidth } from '../project_editor/cross_item_actions.js';
-import { guideColorDark, guideColorLight, guideColorMedium } from '../project_editor/guide.js';
+import { gridColor, guideColorDark, guideColorLight, guideColorMedium } from '../project_editor/guide.js';
 import { runQualityChecksForItem } from '../project_editor/quality_checks.js';
 import { drawCharacterKernExtra, drawContextCharacters } from './context_characters.js';
 import {
@@ -197,9 +197,9 @@ export class EditCanvas extends HTMLElement {
 			const guidesSettings = editor.project.settings.app.guides;
 			if (!guidesSettings.drawGuidesOnTop) {
 				// if (guidesSettings.systemShowGuides) drawSystemGuidelines(!shouldDrawContextCharacters());
+				if (guidesSettings.gridShow) drawGrid();
 				if (guidesSettings.systemShowGuides) drawSystemGuidelines();
 				if (guidesSettings.customShowGuides) drawCustomGuidelines();
-				if (guidesSettings.gridShow) drawGrid();
 			}
 
 			// Draw glyphs
@@ -250,9 +250,9 @@ export class EditCanvas extends HTMLElement {
 			// Guides (if draw on top)
 			if (guidesSettings.drawGuidesOnTop) {
 				// if (guidesSettings.systemShowGuides) drawSystemGuidelines(!shouldDrawContextCharacters());
+				if (guidesSettings.gridShow) drawGrid();
 				if (guidesSettings.systemShowGuides) drawSystemGuidelines();
 				if (guidesSettings.customShowGuides) drawCustomGuidelines();
-				if (guidesSettings.gridShow) drawGrid();
 			}
 
 			const contextCharacterSettings = editor.project.settings.app.contextCharacters;
@@ -461,15 +461,15 @@ export class EditCanvas extends HTMLElement {
 			let y0 = Math.floor(cYsY(height) / gridSquareSize) * gridSquareSize;
 			let y1 = Math.ceil(cYsY(0) / gridSquareSize) * gridSquareSize;
 
-			setSystemGuideColor(
-				'medium',
-				transparencyToAlpha(editor.project.settings.app.guides.gridTransparency)
-			);
+			// log(`fill: ${fill}`);
+			let alpha = transparencyToAlpha(editor.project.settings.app.guides.gridTransparency);
+			const fill = getColorFromRGBA(gridColor, alpha);
+			ctx.fillStyle = fill;
 			for (let x = x0; x <= x1; x += gridSquareSize) {
-				ctx.fillRect(sXcX(x), 0, 1, height);
+				ctx.fillRect(Math.floor(sXcX(x)), 0, 1, height);
 			}
 			for (let y = y0; y <= y1; y += gridSquareSize) {
-				ctx.fillRect(0, sYcY(y), width, 1);
+				ctx.fillRect(0, Math.floor(sYcY(y)), width, 1);
 			}
 		}
 

--- a/src/edit_canvas/tools/path_edit.js
+++ b/src/edit_canvas/tools/path_edit.js
@@ -208,6 +208,17 @@ export class Tool_PathEdit {
 						}
 					}
 				}
+				let guides = editor.project.settings.app.guides;
+				if (guides.gridShow && guides.gridSnap) {
+					let gridSquareSize = editor.project.settings.font.upm / guides.gridDivisions;
+					const mouse = { x: cXsX(ehd.mousePosition.x), y: cYsY(ehd.mousePosition.y) };
+					const mouseSnapped = {
+						x: Math.round(mouse.x / gridSquareSize) * gridSquareSize,
+						y: Math.round(mouse.y / gridSquareSize) * gridSquareSize,
+					};
+					dx = mouseSnapped.x - this.controlPoint.x;
+					dy = mouseSnapped.y - this.controlPoint.y;
+				}
 
 				// --------------------------------------------------------------
 				// Locking

--- a/src/panels/cards.js
+++ b/src/panels/cards.js
@@ -207,6 +207,13 @@ export function makeSingleInput(item, property, thisTopic, tagName, additionalLi
 			// log(`item[property]: ${item[property]}`);
 		}
 
+		// Special Case: gridDivisions property
+		if (property === 'gridDivisions') {
+			if(newValue < 1) newValue = 1;
+			item[property] = newValue;
+			editor.publish('editCanvasView', item);
+		}
+
 		// log(`topics: ${topics}`);
 		if (item.objType === 'VirtualGlyph') {
 			topics.forEach((topic) => editor.publish(topic, editor.selectedItem));

--- a/src/panels/guides.js
+++ b/src/panels/guides.js
@@ -10,13 +10,7 @@ import {
 	guideColorMedium,
 } from '../project_editor/guide.js';
 import { makeActionButton } from './action_buttons.js';
-import {
-	makeDirectCheckbox,
-	makeSingleCheckbox,
-	makeSingleInput,
-	makeSingleLabel,
-	rowPad,
-} from './cards.js';
+import { makeDirectCheckbox, makeSingleInput, makeSingleLabel, rowPad } from './cards.js';
 import { refreshPanel } from './panels.js';
 
 // --------------------------------------------------------------

--- a/src/panels/guides.js
+++ b/src/panels/guides.js
@@ -10,7 +10,13 @@ import {
 	guideColorMedium,
 } from '../project_editor/guide.js';
 import { makeActionButton } from './action_buttons.js';
-import { makeDirectCheckbox, makeSingleInput, makeSingleLabel, rowPad } from './cards.js';
+import {
+	makeDirectCheckbox,
+	makeSingleCheckbox,
+	makeSingleInput,
+	makeSingleLabel,
+	rowPad,
+} from './cards.js';
 import { refreshPanel } from './panels.js';
 
 // --------------------------------------------------------------
@@ -25,6 +31,7 @@ export function makePanel_Guides() {
 	const guides = getCurrentProject().settings.app.guides;
 	const showSystem = guides.systemShowGuides;
 	const showCustom = guides.customShowGuides;
+	const showGrid = guides.gridShow;
 	addAsChildren(viewOptionsCard, [
 		makeDirectCheckbox(guides, 'drawGuidesOnTop', refreshGuideChange),
 		makeElement({
@@ -79,9 +86,29 @@ export function makePanel_Guides() {
 		]);
 	}
 
+	const gridShowCheckbox = makeDirectCheckbox(guides, 'gridShow');
+	gridShowCheckbox.addEventListener('change', () => {
+		getCurrentProjectEditor().navigate();
+	});
+	addAsChildren(viewOptionsCard, [
+		gridShowCheckbox,
+		makeElement({ tag: 'h4', content: 'Grid guide' }),
+	]);
+	if (showGrid) {
+		addAsChildren(viewOptionsCard, [
+			makeElement(),
+			makeSingleLabel('Transparency'),
+			makeFancySlider(guides.gridTransparency, (newValue) => {
+				guides.gridTransparency = newValue;
+				getCurrentProjectEditor().editCanvas.redraw('guides grid transparency');
+			})
+		]);
+	}
+
 	let result = [viewOptionsCard];
 	if (showSystem) result.push(makeSystemGuidesCard());
 	if (showCustom) result.push(makeCustomGuidesCard());
+	if (showGrid) result.push(makeGridCard());
 	return result;
 }
 
@@ -272,4 +299,40 @@ function makeCustomGuideRow(guide, number) {
 	valueInput.setAttribute('title', 'Guide line position');
 
 	return [viewCheckbox, nameInput, deleteButton, colorButton, angleButton, valueInput];
+}
+
+function makeGridCard() {
+	const guides = getCurrentProject().settings.app.guides;
+	const gridCard = makeElement({
+		className: 'panel__card guides-card__grid',
+		innerHTML: '<h3>Grid</h3>',
+	});
+
+	const gridSquareSize = makeElement({
+		tag:'i',
+		innerHTML : "Grid square size: " + getCurrentProjectEditor().project.settings.font.upm / guides.gridDivisions + " units",
+	});
+	const valueInput = makeSingleInput(guides, 'gridDivisions', 'editCanvasView', 'input-number', ['change']);
+	valueInput.addEventListener('change', () => {
+		gridSquareSize.innerHTML = "Grid square size: " + getCurrentProjectEditor().project.settings.font.upm / valueInput.value + " units";
+	});
+	const divisionsContainer = makeElement({
+		tag: 'span',
+		className: 'divisions-container',
+	});
+	addAsChildren(divisionsContainer, [
+		valueInput,
+		gridSquareSize,
+	]);
+	valueInput.setAttribute('title', 'Grid divisions');
+	addAsChildren(gridCard, [
+		makeElement(),
+		makeSingleLabel('Grid divisions'),
+		divisionsContainer,
+		makeElement(),
+		makeSingleLabel('Snapping'),
+		makeDirectCheckbox(guides, 'gridSnap', undefined),
+		rowPad(),
+	]);
+	return gridCard;
 }

--- a/src/panels/guides.js
+++ b/src/panels/guides.js
@@ -1,6 +1,7 @@
 import { getCurrentProject, getCurrentProjectEditor } from '../app/main.js';
 import { makeRandomSaturatedColor, parseColorString, rgbToHex } from '../common/colors.js';
 import { addAsChildren, makeElement } from '../common/dom.js';
+import { round } from '../common/functions.js';
 import { makeIcon } from '../common/graphics.js';
 import { makeFancySlider } from '../controls/fancy-slider/fancy_slider.js';
 import {
@@ -41,7 +42,7 @@ export function makePanel_Guides() {
 	});
 	addAsChildren(viewOptionsCard, [
 		systemShowGuidesCheckbox,
-		makeElement({ tag: 'h4', content: 'Key metrics guides' }),
+		makeElement({ tag: 'h4', content: 'Show: Key metrics guides' }),
 	]);
 	if (showSystem) {
 		addAsChildren(viewOptionsCard, [
@@ -64,7 +65,7 @@ export function makePanel_Guides() {
 	});
 	addAsChildren(viewOptionsCard, [
 		customShowGuidesCheckbox,
-		makeElement({ tag: 'h4', content: 'Custom guides' }),
+		makeElement({ tag: 'h4', content: 'Show: Custom guides' }),
 	]);
 	if (showCustom) {
 		addAsChildren(viewOptionsCard, [
@@ -77,6 +78,7 @@ export function makePanel_Guides() {
 			makeElement(),
 			makeSingleLabel('Show labels'),
 			makeDirectCheckbox(guides, 'customShowLabels', refreshGuideChange),
+			rowPad(),
 		]);
 	}
 
@@ -86,7 +88,7 @@ export function makePanel_Guides() {
 	});
 	addAsChildren(viewOptionsCard, [
 		gridShowCheckbox,
-		makeElement({ tag: 'h4', content: 'Grid guide' }),
+		makeElement({ tag: 'h4', content: 'Show: Grid' }),
 	]);
 	if (showGrid) {
 		addAsChildren(viewOptionsCard, [
@@ -95,7 +97,7 @@ export function makePanel_Guides() {
 			makeFancySlider(guides.gridTransparency, (newValue) => {
 				guides.gridTransparency = newValue;
 				getCurrentProjectEditor().editCanvas.redraw('guides grid transparency');
-			})
+			}),
 		]);
 	}
 
@@ -303,28 +305,42 @@ function makeGridCard() {
 	});
 
 	const gridSquareSize = makeElement({
-		tag:'i',
-		innerHTML : "Grid square size: " + getCurrentProjectEditor().project.settings.font.upm / guides.gridDivisions + " units",
+		tag: 'code',
+		innerHTML:
+			'' +
+			round(getCurrentProjectEditor().project.settings.font.upm / guides.gridDivisions, 2) +
+			' Em',
 	});
-	const valueInput = makeSingleInput(guides, 'gridDivisions', 'editCanvasView', 'input-number', ['change']);
+	// gridSquareSize.setAttribute('disabled', 'disabled');
+
+	const valueInput = makeSingleInput(guides, 'gridDivisions', 'editCanvasView', 'input-number');
 	valueInput.addEventListener('change', () => {
-		gridSquareSize.innerHTML = "Grid square size: " + getCurrentProjectEditor().project.settings.font.upm / valueInput.value + " units";
+		gridSquareSize.innerHTML =
+			'' + round(getCurrentProjectEditor().project.settings.font.upm / valueInput.value, 2) + ' Em';
 	});
 	const divisionsContainer = makeElement({
 		tag: 'span',
 		className: 'divisions-container',
 	});
-	addAsChildren(divisionsContainer, [
-		valueInput,
-		gridSquareSize,
-	]);
+	addAsChildren(divisionsContainer, [valueInput, gridSquareSize]);
 	valueInput.setAttribute('title', 'Grid divisions');
 	addAsChildren(gridCard, [
 		makeElement(),
-		makeSingleLabel('Grid divisions'),
+		makeSingleLabel(
+			'Grid divisions',
+			'For the Em square of this font, how many divisions should the grid have?'
+		),
 		divisionsContainer,
 		makeElement(),
-		makeSingleLabel('Snapping'),
+		makeSingleLabel(
+			'Grid square size',
+			'The size of each square in the grid, based on the number of divisions and the UPM of this font.'
+		),
+		gridSquareSize,
+		makeSingleLabel(
+			'Snap path points',
+			'Snap path points to grid intersections when moving or creating points.'
+		),
 		makeDirectCheckbox(guides, 'gridSnap', undefined),
 		rowPad(),
 	]);

--- a/src/panels/panels.css
+++ b/src/panels/panels.css
@@ -840,6 +840,20 @@ nav .item-chooser__wrapper {
 	width: 90px;
 }
 
+.guides-card__grid .divisions-container {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+}
+
+.guides-card__grid .divisions-container i {
+	color: var(--gray-l60);
+}
+
+.guides-card__grid input-number {
+	width: 90px;
+}
+
 .guides-card__system label {
 	grid-column: auto;
 }

--- a/src/project_data/glyphr_studio_project.js
+++ b/src/project_data/glyphr_studio_project.js
@@ -76,6 +76,10 @@ export class GlyphrStudioProject {
 					customShowLabels: false,
 					customTransparency: 70,
 					custom: [],
+					gridShow: false,
+					gridTransparency: 70,
+					gridDivisions: 10,
+					gridSnap: false,
 				},
 				contextCharacters: {
 					showCharacters: false,

--- a/src/project_data/glyphr_studio_project.js
+++ b/src/project_data/glyphr_studio_project.js
@@ -77,7 +77,7 @@ export class GlyphrStudioProject {
 					customTransparency: 70,
 					custom: [],
 					gridShow: false,
-					gridTransparency: 70,
+					gridTransparency: 90,
 					gridDivisions: 10,
 					gridSnap: false,
 				},

--- a/src/project_editor/guide.js
+++ b/src/project_editor/guide.js
@@ -59,3 +59,4 @@ export const defaultCustomGuideColor = 'rgb(127, 0, 255)';
 export const guideColorLight = 'rgb(227, 190, 171)';
 export const guideColorMedium = 'rgb(212, 154, 125)';
 export const guideColorDark = 'rgb(191, 106, 64)';
+export const gridColor = 'rgb(96, 96, 136)';

--- a/src/project_editor/import_project.js
+++ b/src/project_editor/import_project.js
@@ -209,6 +209,12 @@ function migrate__v1_13_2_to_v2_0_0(oldProject) {
 	// Guides
 	newGuides.systemTransparency = oldColors.systemguidetransparency || 70;
 	newGuides.customTransparency = oldColors.systemguidetransparency || 70;
+	newGuides.gridDivisions = oldSettings.griddivisions;
+	newGuides.gridSnap = oldSettings.snaptogrid;
+	// Seems it's a string in v1 ???
+	let gridTransparency = Number(oldColors.gridtransparency);
+	newGuides.gridShow = gridTransparency !== 100;
+	newGuides.gridTransparency = gridTransparency;
 	if (oldGuides && Object.keys(oldGuides).length) {
 		Object.keys(oldGuides).forEach((key) => {
 			let oldGuide = oldGuides[key];


### PR DESCRIPTION
Missed this from v1.
I think I've done everything somewhat correctly?
Currently the snapping only work when editing path points, not sure if it would be interesting if it were to work on the path itself.

Edit: Just realized there's no way to make the number input have a minimum, should I add that?