### PR TITLE
Separate app configs from project; add persistent storage

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -12,12 +12,28 @@ import * as config from './app_config.json';
 import { _DEV } from './dev_mode_includes.js';
 import {
 	addProjectEditorAndSetAsImportTarget,
+	getConfigGroup,
 	getCurrentProject,
 	getGlyphrStudioApp,
 	getProjectEditorImportTarget,
 	setCurrentProjectEditor,
 } from './main.js';
 import { makePage_OpenProject } from './open_project.js';
+
+// Do some extra stuff during config assignments
+let timeoutId;
+const configHandler = {
+	set(target, key, value) {
+		// Storage saving with debouncing
+		window.clearTimeout(timeoutId);
+		timeoutId = window.setTimeout(() => {
+			getGlyphrStudioApp().saveAppSettings();
+		}, 1000);
+
+		// log(`"${key}" changed from ${target[key]} to ${value}`);
+		return Reflect.set(target, key, value);
+	},
+};
 
 /**
  * Creates a new Glyphr Studio Application
@@ -45,6 +61,40 @@ export class GlyphrStudioApp {
 				testOnRedraw: function () {}, // code to run on Edit Canvas redraw
 			},
 			telemetry: true, // Load google analytics
+			storageWriteEnabled: true,
+			app: new Proxy(
+				{
+					stopPageNavigation: true,
+					formatSaveFile: false,
+					saveLivePreviews: true,
+					autoSave: true,
+					savePreferences: false,
+					unlinkComponentInstances: true,
+					directlyDragCurves: true,
+					canvasDisplayModeFilled: true,
+					showNonCharPoints: false,
+					itemChooserPageSize: 256,
+					previewText: false,
+					exportLigatures: true,
+					exportKerning: true,
+					exportUneditedItems: true,
+					moveShapesOnSVGDragDrop: false,
+					autoSideBearingsOnSVGDragDrop: 50,
+					autoRightBearingOnFirstShape: 50,
+					highlightPointsNearPoints: 2,
+					highlightPointsNearHandles: 2,
+					highlightPointsNearXZero: 2,
+					highlightPointsNearYZero: 2,
+					contextCharacters: {
+						showCharacters: false,
+						characterTransparency: 20,
+						showGuides: true,
+						guidesTransparency: 70,
+					},
+					livePreviews: [],
+				},
+				configHandler
+			),
 		};
 
 		// Version
@@ -66,6 +116,8 @@ export class GlyphrStudioApp {
 	 * Starts up the app
 	 */
 	setUp() {
+		this.loadAppSettings();
+
 		// log(`GlyphrStudioApp.setUp`, 'start');
 		let editor = addProjectEditorAndSetAsImportTarget();
 
@@ -260,6 +312,10 @@ export class GlyphrStudioApp {
 		// log(`key: ${key}`);
 		// log(`\n⮟data⮟`);
 		// log(newData);
+		// log(`Storage writing enabled: ${this.settings.storageWriteEnabled}`);
+		if (!this.settings.storageWriteEnabled) {
+			return new Error('Storage writes are disabled');
+		}
 
 		const data = this.getLocalStorage();
 		data[key] = newData;
@@ -267,14 +323,17 @@ export class GlyphrStudioApp {
 			window.localStorage.setItem('GlyphrStudio', JSON.stringify(data));
 		} catch {
 			showToast(
-				`There is not enough space for this project to be auto-saved. The auto-save option has been turned off in Settings > App.`
+				`There is not enough space in local storage. Auto-saves have been turned off in Settings > App and app setting changes will not persist.`
 			);
-			getCurrentProject().settings.app.autoSave = false;
+			this.settings.app.autoSave = false;
+			this.settings.storageWriteEnabled = false;
+			return new Error('Unable to write to storage');
 		}
 
 		// log(`\n⮟window.localStorage⮟`);
 		// log(window.localStorage);
 		// log(`GlyphrStudioApp.setLocalStorage`, 'end');
+		return true;
 	}
 
 	/**
@@ -308,6 +367,32 @@ export class GlyphrStudioApp {
 		// log(newSaves);
 		this.setLocalStorage('autoSaves', newSaves);
 		// log(`addAutoSaveState`, 'end');
+	}
+
+	/**
+	 * Loads the app settings saved in storage.
+	 */
+	loadAppSettings() {
+		// log(`getAppSettings`, 'start');
+		let newSettings = this.getLocalStorage()?.appSettings || {};
+		// log(`\n⮟newSettings⮟`);
+		// log(newSettings);
+		Object.assign(this.settings.app, newSettings);
+	}
+
+	/**
+	 * Updates the saved app settings.
+	 */
+	saveAppSettings() {
+		// log(`saveAppSettings`, 'start');
+		const settings = this.settings.app;
+		// log(`\n⮟oldSettings⮟`);
+		// log(settings);
+		let newSettings = this.getLocalStorage()?.appSettings || {};
+		newSettings = settings;
+		// log(`\n⮟newSettings⮟`);
+		// log(newSettings);
+		this.setLocalStorage('appSettings', newSettings);
 	}
 }
 
@@ -347,7 +432,7 @@ export function updateWindowUnloadEvent() {
 		} else {
 			window.onbeforeunload = () => {};
 		}
-	} else if (project.settings.app.stopPageNavigation) {
+	} else if (getConfigGroup('app').stopPageNavigation) {
 		window.onbeforeunload = showBeforeUnloadConfirmation;
 	} else {
 		window.onbeforeunload = () => {};

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -24,11 +24,12 @@ import { makePage_OpenProject } from './open_project.js';
 let timeoutId;
 const configHandler = {
 	set(target, key, value) {
+		let app = getGlyphrStudioApp();
 		// Storage saving with debouncing
 		window.clearTimeout(timeoutId);
 		timeoutId = window.setTimeout(() => {
-			getGlyphrStudioApp().saveAppSettings();
-		}, 1000);
+			app.saveAppSettings();
+		}, app.settings.settingsDebounceTime);
 
 		// log(`"${key}" changed from ${target[key]} to ${value}`);
 		return Reflect.set(target, key, value);
@@ -63,6 +64,7 @@ export class GlyphrStudioApp {
 			},
 			telemetry: true, // Load google analytics
 			storageWriteEnabled: true,
+			settingsDebounceTime: 1000, // Filter persistent saving rapid inputs by this
 			app: new Proxy(
 				{
 					stopPageNavigation: true,

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -399,6 +399,13 @@ export class GlyphrStudioApp {
 			this.setLocalStorage('appSettings', newSettings);
 		}
 	}
+	/**
+	 * Fully reset app configs, including stored
+	 */
+	resetAppSettings() {
+		this.setLocalStorage('appSettings', '');
+		this.settings.app = new GlyphrStudioApp().settings.app;
+	}
 }
 
 /**

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -54,6 +54,7 @@ export class GlyphrStudioApp {
 				currentTool: false, // {Tool name} select a tool
 				stopPageNavigation: false, // {bool} overwrite project-level setting
 				autoSave: false, // {bool} trigger auto saves
+				saveSettings: false, // {bool} enable settings persistent storage
 				selectFirstShape: false, // {bool} select the first shape
 				selectFirstPoint: false, // {bool} select the first path point
 				testActions: [], // {name: '', onClick: ()=>{}} adds test actions to the Glyph card
@@ -384,15 +385,17 @@ export class GlyphrStudioApp {
 	 * Updates the saved app settings.
 	 */
 	saveAppSettings() {
-		// log(`saveAppSettings`, 'start');
-		const settings = this.settings.app;
-		// log(`\n⮟oldSettings⮟`);
-		// log(settings);
-		let newSettings = this.getLocalStorage()?.appSettings || {};
-		newSettings = settings;
-		// log(`\n⮟newSettings⮟`);
-		// log(newSettings);
-		this.setLocalStorage('appSettings', newSettings);
+		if (!this.settings.dev.saveSettings) {
+			// log(`saveAppSettings`, 'start');
+			const settings = this.settings.app;
+			// log(`\n⮟oldSettings⮟`);
+			// log(settings);
+			let newSettings = this.getLocalStorage()?.appSettings || {};
+			newSettings = settings;
+			// log(`\n⮟newSettings⮟`);
+			// log(newSettings);
+			this.setLocalStorage('appSettings', newSettings);
+		}
 	}
 }
 

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -165,6 +165,23 @@ export function getCurrentProjectEditor() {
 }
 
 /**
+ * Retrieve a configuration group.
+ *
+ * Groups:
+ * - `app`: User configs defining app/editor behavior.
+ * - `project`: Defines general project settings like name and enabled ranges. Uses active project.
+ * - `font`: Font-specific stuff like em and metadata. Uses active project.
+ * @param {string} groupName - Configuration group to target
+ */
+export function getConfigGroup(groupName) {
+	if (groupName == 'app') {
+		return GSApp.settings[groupName];
+	} else {
+		return getCurrentProject().settings[groupName];
+	}
+}
+
+/**
  * Sets the current Project Editor
  * @param {ProjectEditor} newEditor - one to set
  */

--- a/src/app/menu.js
+++ b/src/app/menu.js
@@ -17,7 +17,7 @@ import { ioSVG_exportSVGfont } from '../formats_io/svg_font/svg_font_export.js';
 import { makeFileName } from '../project_editor/file_io.js';
 import { emailLink } from './app.js';
 import { makePage_CrossProjectActions } from './cross_project_actions/cross_project_actions.js';
-import { getCurrentProjectEditor, getGlyphrStudioApp } from './main.js';
+import { getConfigGroup, getCurrentProjectEditor, getGlyphrStudioApp } from './main.js';
 import { makePage_OpenProject } from './open_project.js';
 
 // --------------------------------------------------------------
@@ -93,7 +93,7 @@ function makeMenu(menuName) {
 		// for new projects) drives the file name preview and the Ctrl+E note.
 		const preferredExportFormat = getPreferredExportFormat();
 		if (typeof editor.loadedFileHandle === 'object') {
-			let projectDisplayName = `${editor.project.settings.project.name} - Glyphr Studio Project.gs2`;
+			let projectDisplayName = `${getConfigGroup('project').name} - Glyphr Studio Project.gs2`;
 
 			// @ts-expect-error 'property does exist'
 			if (typeof editor?.loadedFileHandle?.name === 'string') {
@@ -143,11 +143,9 @@ function makeMenu(menuName) {
 			{
 				child: makeElement({
 					tag: 'h2',
-					content:
-						`${editor.project.settings.font.family}-${editor.project.settings.font.style}.${preferredExportFormat}`.replaceAll(
-							' ',
-							''
-						),
+					content: `${getConfigGroup('font').family}-${
+						getConfigGroup('font').style
+					}.${preferredExportFormat}`.replaceAll(' ', ''),
 				}),
 				className: 'spanAll',
 			},
@@ -332,7 +330,7 @@ function makeProjectPreviewRow(projectID = 0) {
 			});
 		}
 		title.innerHTML = projectEditor.project.settings.project.name;
-		let previewText = projectEditor.project.settings.app.previewText || 'Aa Bb Cc Xx Yy Zz';
+		let previewText = getConfigGroup('app').previewText || 'Aa Bb Cc Xx Yy Zz';
 		thumbnail = makeElement({
 			tag: 'display-canvas',
 			attributes: {

--- a/src/app/tests/app.test.js
+++ b/src/app/tests/app.test.js
@@ -1,0 +1,32 @@
+import { SpyModule } from 'vitest/internal/browser';
+import { getGlyphrStudioApp } from '../main.js';
+
+describe('config storage', () => {
+	it('ensure single write', async () => {
+		let app = getGlyphrStudioApp();
+		const saveSpy = SpyModule.spyOn(app, 'saveAppSettings');
+
+		for (let i = 0; i < 5; i++) {
+			app.settings.app[`testProp${i}`] = true;
+		}
+
+		// Wait past the 1s debounce + small buffer
+		await new Promise((resolve) => setTimeout(resolve, app.settings.settingsDebounceTime));
+
+		expect(saveSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('ensure debounced', async () => {
+		let app = getGlyphrStudioApp();
+		const before = localStorage.getItem('GlyphrStudio');
+		app.settings.app.testBool = true;
+
+		// The debounce timer is still pending — no save yet
+		await new Promise((resolve) => setTimeout(resolve, app.settings.settingsDebounceTime / 2));
+		expect(localStorage.getItem('GlyphrStudio')).toEqual(before);
+
+		// After the full length it should have fired
+		await new Promise((resolve) => setTimeout(resolve, app.settings.settingsDebounceTime / 2 + 10));
+		expect(JSON.parse(localStorage.getItem('GlyphrStudio'))?.appSettings.testBool).toBe(true);
+	});
+});

--- a/src/controls/font-preview/font_preview.js
+++ b/src/controls/font-preview/font_preview.js
@@ -1,6 +1,6 @@
 /* global Buffer */
 import { FontFlux } from 'font-flux-js';
-import { getCurrentProject } from '../../app/main.js';
+import { getConfigGroup, getCurrentProject } from '../../app/main.js';
 import { charToHex } from '../../common/character_ids.js';
 import { makeElement } from '../../common/dom.js';
 import { caseCamelToKebab, caseKebabToCamel, round } from '../../common/functions.js';
@@ -75,7 +75,7 @@ export class FontPreviewBuilder {
 		const previewGlyphs = buildPreviewGlyphObjects(project, glyphMap, ligatures);
 		previewGlyphs.forEach((glyph) => font.addGlyph(glyph));
 
-		if (this.includeKerning && project.settings.app.exportKerning) {
+		if (this.includeKerning && getConfigGroup('app').exportKerning) {
 			writeGposKernDataToFont(font, project);
 		}
 

--- a/src/edit_canvas/context_characters.js
+++ b/src/edit_canvas/context_characters.js
@@ -1,4 +1,4 @@
-import { getCurrentProject, getCurrentProjectEditor } from '../app/main';
+import { getConfigGroup, getCurrentProject, getCurrentProjectEditor } from '../app/main';
 import { charsToHexArray } from '../common/character_ids';
 import { accentColors, getColorFromRGBA, transparencyToAlpha } from '../common/colors';
 import { makeCrisp } from '../common/functions';
@@ -142,9 +142,9 @@ export function drawContextCharacters(ctx) {
 	}
 
 	// Draw label for selected item
-	if (project.settings.app.contextCharacters.showGuides) {
+	if (getConfigGroup('app').contextCharacters.showGuides) {
 		const item = editor.selectedItem;
-		const alpha = transparencyToAlpha(project.settings.app.contextCharacters.guidesTransparency);
+		const alpha = transparencyToAlpha(getConfigGroup('app').contextCharacters.guidesTransparency);
 		const textColor = getColorFromRGBA(contextCharacters.labelColors.selected, alpha);
 		drawCharacterNameExtra(
 			ctx,
@@ -207,7 +207,7 @@ export function shouldDrawContextCharacters() {
 	if (!item) return false;
 	if (!item.contextCharacters) return false;
 	if (item.contextCharacters === item.char) return false;
-	if (!editor.project.settings.app.contextCharacters.showCharacters) return false;
+	if (!getConfigGroup('app').contextCharacters.showCharacters) return false;
 	return true;
 }
 
@@ -267,7 +267,7 @@ function drawContextCharacterLeftLineExtras(ctx, char, block) {
 
 	const editor = getCurrentProjectEditor();
 	// Draw baseline from first char to selected item
-	if (editor.project.settings.app.contextCharacters.showGuides) {
+	if (getConfigGroup('app').contextCharacters.showGuides) {
 		drawBaseline(ctx, char.view.dx - 20, char.view.dy, editor.view.dx - char.view.dx + 20);
 	}
 
@@ -308,7 +308,7 @@ function drawContextCharacterRightLineExtras(ctx, char, block) {
 	const underlineWidth = rightHandAdvanceWidth * editor.view.dz;
 	// log(`underlineWidth: ${underlineWidth}`);
 
-	if (editor.project.settings.app.contextCharacters.showGuides) {
+	if (getConfigGroup('app').contextCharacters.showGuides) {
 		drawBaseline(ctx, char.view.dx, char.view.dy, underlineWidth + 20);
 	}
 
@@ -335,7 +335,7 @@ function drawContextCharacterRightLineExtras(ctx, char, block) {
  */
 function drawBaseline(ctx, x, y, width) {
 	// ctx.fillStyle = accentColors.gray.l90;
-	const transparency = getCurrentProject().settings.app.contextCharacters.guidesTransparency;
+	const transparency = getConfigGroup('app').contextCharacters.guidesTransparency;
 	const alpha = transparencyToAlpha(transparency);
 	ctx.fillStyle = getColorFromRGBA(guideColorDark, alpha);
 	ctx.fillRect(x, Math.ceil(y), width, 1);
@@ -350,7 +350,7 @@ function drawContextCharacterExtras(ctx, char) {
 	// log('drawContextCharacterExtras', 'start');
 	// log(char);
 
-	const appSettings = getCurrentProject().settings.app;
+	const appSettings = getConfigGroup('app');
 
 	if (appSettings.contextCharacters.showGuides) {
 		const alpha = transparencyToAlpha(appSettings.contextCharacters.guidesTransparency);
@@ -490,7 +490,7 @@ function drawSingleContextCharacter(ctx, charData) {
 			charData.item,
 			ctx,
 			charData.view,
-			transparencyToAlpha(getCurrentProject().settings.app.contextCharacters.characterTransparency)
+			transparencyToAlpha(getConfigGroup('app').contextCharacters.characterTransparency)
 		);
 	}
 	// log('drawSingleContextCharacter', 'end');
@@ -660,7 +660,7 @@ export function findAndUnderlineHotspot(cx, cy) {
 	const ctx = getCurrentProjectEditor().editCanvas.ctx;
 	// log(`${hs}`);
 	if (hs) {
-		const t = getCurrentProject().settings.app.contextCharacters.guidesTransparency;
+		const t = getConfigGroup('app').contextCharacters.guidesTransparency;
 		// var t2 = (((100 - t) / 2) + t);
 		const alpha = transparencyToAlpha(t);
 		const rgb = getColorFromRGBA('rgb(204,81,0)', alpha);

--- a/src/edit_canvas/edit_canvas.js
+++ b/src/edit_canvas/edit_canvas.js
@@ -1,10 +1,15 @@
-import { getCurrentProject, getCurrentProjectEditor } from '../app/main.js';
+import { getConfigGroup, getCurrentProject, getCurrentProjectEditor } from '../app/main.js';
 import { accentColors, getColorFromRGBA, transparencyToAlpha } from '../common/colors.js';
 import { makeElement } from '../common/dom.js';
 import { clone } from '../common/functions.js';
 import { drawGlyph, drawGlyphOutlineMode } from '../display_canvas/draw_paths.js';
 import { kernGroupSideMaxWidth } from '../project_editor/cross_item_actions.js';
-import { gridColor, guideColorDark, guideColorLight, guideColorMedium } from '../project_editor/guide.js';
+import {
+	gridColor,
+	guideColorDark,
+	guideColorLight,
+	guideColorMedium,
+} from '../project_editor/guide.js';
 import { runQualityChecksForItem } from '../project_editor/quality_checks.js';
 import { drawCharacterKernExtra, drawContextCharacters } from './context_characters.js';
 import {
@@ -194,7 +199,7 @@ export class EditCanvas extends HTMLElement {
 			const ehd = eventHandlerData;
 
 			// Guides
-			const guidesSettings = editor.project.settings.app.guides;
+			const guidesSettings = getConfigGroup('project').guides;
 			if (!guidesSettings.drawGuidesOnTop) {
 				// if (guidesSettings.systemShowGuides) drawSystemGuidelines(!shouldDrawContextCharacters());
 				if (guidesSettings.gridShow) drawGrid();
@@ -203,7 +208,7 @@ export class EditCanvas extends HTMLElement {
 			}
 
 			// Draw glyphs
-			if (project.settings.app.canvasDisplayModeFilled) {
+			if (getConfigGroup('app').canvasDisplayModeFilled) {
 				drawGlyph(currentItem, ctx, view);
 			} else {
 				drawGlyphOutlineMode(currentItem, ctx, view);
@@ -255,7 +260,7 @@ export class EditCanvas extends HTMLElement {
 				if (guidesSettings.customShowGuides) drawCustomGuidelines();
 			}
 
-			const contextCharacterSettings = editor.project.settings.app.contextCharacters;
+			const contextCharacterSettings = getConfigGroup('app').contextCharacters;
 			// Context characters
 			if (contextCharacterSettings.showCharacters) {
 				drawContextCharacters(ctx);
@@ -333,8 +338,8 @@ export class EditCanvas extends HTMLElement {
 
 		function drawSystemGuidelines(drawVerticals = true) {
 			// log(`drawSystemGuidelines`, 'start');
-			const alpha = transparencyToAlpha(project.settings.app.guides.systemTransparency);
-			const showLabels = project.settings.app.guides.systemShowLabels;
+			const alpha = transparencyToAlpha(getConfigGroup('project').guides.systemTransparency);
+			const showLabels = getConfigGroup('project').guides.systemShowLabels;
 			// Horizontals
 			let deltaY = 0;
 
@@ -433,7 +438,7 @@ export class EditCanvas extends HTMLElement {
 		}
 
 		function drawCustomGuidelines() {
-			const guides = getCurrentProject().settings.app.guides;
+			const guides = getConfigGroup('project').guides;
 
 			if (guides.custom) {
 				let alpha = transparencyToAlpha(guides.customTransparency);
@@ -455,14 +460,14 @@ export class EditCanvas extends HTMLElement {
 
 		function drawGrid() {
 			const gridSquareSize =
-				editor.project.settings.font.upm / editor.project.settings.app.guides.gridDivisions;
+				getConfigGroup('font').upm / getConfigGroup('project').guides.gridDivisions;
 			let x0 = Math.floor(cXsX(0) / gridSquareSize) * gridSquareSize;
 			let x1 = Math.ceil(cXsX(width) / gridSquareSize) * gridSquareSize;
 			let y0 = Math.floor(cYsY(height) / gridSquareSize) * gridSquareSize;
 			let y1 = Math.ceil(cYsY(0) / gridSquareSize) * gridSquareSize;
 
 			// log(`fill: ${fill}`);
-			let alpha = transparencyToAlpha(editor.project.settings.app.guides.gridTransparency);
+			let alpha = transparencyToAlpha(getConfigGroup('project').guides.gridTransparency);
 			const fill = getColorFromRGBA(gridColor, alpha);
 			ctx.fillStyle = fill;
 			for (let x = x0; x <= x1; x += gridSquareSize) {

--- a/src/edit_canvas/events_drag_drop_paste.js
+++ b/src/edit_canvas/events_drag_drop_paste.js
@@ -1,4 +1,4 @@
-import { getCurrentProject, getCurrentProjectEditor } from '../app/main.js';
+import { getConfigGroup, getCurrentProjectEditor } from '../app/main.js';
 import { showToast } from '../controls/dialogs/dialogs.js';
 import { ioSVG_convertSVGTagsToGlyph } from '../formats_io/svg_outlines/svg_outline_import.js';
 import { copyShapesFromTo } from '../project_editor/actions.js';
@@ -34,12 +34,12 @@ export function importSVGtoCurrentItem(svgData, sourceText = 'SVG') {
 		msShapes.clear();
 		newShapes.forEach((shape) => msShapes.add(shape));
 
-		const appSettings = getCurrentProject().settings.app;
+		const appSettings = getConfigGroup('app');
 		if (appSettings.autoSideBearingsOnSVGDragDrop > -1) {
 			const sbValue = appSettings.autoSideBearingsOnSVGDragDrop;
 			msShapes.setShapePosition(sbValue);
 			editor.selectedItem.advanceWidth = msShapes.maxes.width + sbValue * 2;
-		} else if (getCurrentProject().settings.app.moveShapesOnSVGDragDrop) {
+		} else if (getConfigGroup('app').moveShapesOnSVGDragDrop) {
 			msShapes.setShapePosition(0, msShapes.maxes.height);
 		}
 

--- a/src/edit_canvas/events_keyboard.js
+++ b/src/edit_canvas/events_keyboard.js
@@ -1,4 +1,4 @@
-import { getCurrentProjectEditor, getGlyphrStudioApp } from '../app/main.js';
+import { getConfigGroup, getCurrentProjectEditor, getGlyphrStudioApp } from '../app/main.js';
 import { makeElement } from '../common/dom.js';
 import { closeEveryTypeOfDialog, showToast } from '../controls/dialogs/dialogs.js';
 import { DisplayCanvas } from '../display_canvas/display_canvas.js';
@@ -484,7 +484,7 @@ function addHideUIOverlay() {
 		//const scale = this.options.fontSize / this.project.totalVertical;
 		const fontSize = editor.project.totalVertical * editor.view.dz;
 		let text = editor.selectedItem.char;
-		if (editor.project.settings.app.contextCharacters.showCharacters) {
+		if (getConfigGroup('app').contextCharacters.showCharacters) {
 			text = editor.selectedItem.contextCharacters;
 		}
 		const advance = getItemStringAdvanceWidth(text) + 100;

--- a/src/edit_canvas/tools/new_path.js
+++ b/src/edit_canvas/tools/new_path.js
@@ -1,4 +1,4 @@
-import { getCurrentProject, getCurrentProjectEditor } from '../../app/main.js';
+import { getConfigGroup, getCurrentProject, getCurrentProjectEditor } from '../../app/main.js';
 import { insertAfter, makeElement } from '../../common/dom.js';
 import { Path } from '../../project_data/path.js';
 import { PathPoint } from '../../project_data/path_point.js';
@@ -30,8 +30,8 @@ export class Tool_NewPath {
 		const msPoints = editor.multiSelect.points;
 
 		// New point
-		// log(`editor.project.settings.font.upm: ${editor.project.settings.font.upm}`);
-		let newPoint = new PathPoint({ projectUPM: editor.project.settings.font.upm });
+		// log(`getConfigGroup('font').upm: ${getConfigGroup('font').upm}`);
+		let newPoint = new PathPoint({ projectUPM: getConfigGroup('font').upm });
 		newPoint.p.x = cXsX(ehd.mousePosition.x);
 		newPoint.p.y = cYsY(ehd.mousePosition.y);
 
@@ -105,9 +105,8 @@ export class Tool_NewPath {
 		const editor = getCurrentProjectEditor();
 
 		if (this.dragging) {
-
-					// log(`\n⮟this.currentPoint⮟`);
-					// log(this.currentPoint);
+			// log(`\n⮟this.currentPoint⮟`);
+			// log(this.currentPoint);
 			// avoid really small handles
 			if (
 				Math.abs(sXcX(this.currentPoint.p.x) - ehd.mousePosition.x) > canvasUIPointSize ||

--- a/src/edit_canvas/tools/path_edit.js
+++ b/src/edit_canvas/tools/path_edit.js
@@ -1,4 +1,4 @@
-import { getCurrentProjectEditor } from '../../app/main.js';
+import { getConfigGroup, getCurrentProjectEditor } from '../../app/main.js';
 import { calculateAngle, radiansToNiceAngle } from '../../common/functions.js';
 import { refreshPanel } from '../../panels/panels.js';
 import { findAndCallHotspot } from '../context_characters.js';
@@ -208,9 +208,9 @@ export class Tool_PathEdit {
 						}
 					}
 				}
-				let guides = editor.project.settings.app.guides;
+				let guides = getConfigGroup('project').guides;
 				if (guides.gridShow && guides.gridSnap) {
-					let gridSquareSize = editor.project.settings.font.upm / guides.gridDivisions;
+					let gridSquareSize = getConfigGroup('font').upm / guides.gridDivisions;
 					const mouse = { x: cXsX(ehd.mousePosition.x), y: cYsY(ehd.mousePosition.y) };
 					const mouseSnapped = {
 						x: Math.round(mouse.x / gridSquareSize) * gridSquareSize,
@@ -297,7 +297,7 @@ export class Tool_PathEdit {
 			editor.publish('currentItem', editor.selectedItem);
 		} else {
 			const editor = getCurrentProjectEditor();
-			if (editor.project.settings.app.directlyDragCurves) {
+			if (getConfigGroup('app').directlyDragCurves) {
 				this.overCurve = false;
 				let singleShape = editor.multiSelect.shapes.singleton;
 				if (singleShape && singleShape.objType !== 'ComponentInstance') {

--- a/src/edit_canvas/tools/tools.js
+++ b/src/edit_canvas/tools/tools.js
@@ -1,4 +1,4 @@
-import { getCurrentProject, getCurrentProjectEditor } from '../../app/main.js';
+import { getConfigGroup, getCurrentProjectEditor } from '../../app/main.js';
 import { accentColors } from '../../common/colors.js';
 import { addAsChildren, makeElement } from '../../common/dom.js';
 import { round, valuesAreClose } from '../../common/functions.js';
@@ -148,7 +148,7 @@ export function makeViewToolsButtons() {
 
 	let viewButtonElements = {};
 	const editor = getCurrentProjectEditor();
-	const displayMode = getCurrentProject().settings.app.canvasDisplayModeFilled;
+	const displayMode = getConfigGroup('app').canvasDisplayModeFilled;
 
 	Object.keys(viewButtonTitles).forEach((buttonName) => {
 		// log(`buttonName: ${buttonName}`);
@@ -190,7 +190,7 @@ export function makeViewToolsButtons() {
 				subscriberID: `tools.displayMode`,
 				callback: () => {
 					let buttonSVG = 'displayModeOutlined';
-					const displayMode = getCurrentProject().settings.app.canvasDisplayModeFilled;
+					const displayMode = getConfigGroup('app').canvasDisplayModeFilled;
 					if (displayMode) buttonSVG = 'displayModeFilled';
 					newToolButton.innerHTML = makeToolButtonSVG({ name: buttonSVG, selected: false });
 				},
@@ -283,7 +283,7 @@ export function selectTool(tool) {
 		if (tool === 'zoomIn') editor.view = { dz: (editor.view.dz *= 1.1) };
 		if (tool === 'zoomOut') editor.view = { dz: (editor.view.dz *= 0.9) };
 		if (tool === 'displayMode') {
-			const appSettings = getCurrentProject().settings.app;
+			const appSettings = getConfigGroup('app');
 			appSettings.canvasDisplayModeFilled = !appSettings.canvasDisplayModeFilled;
 			// log(`canvasDisplayModeFilled: ${appSettings.canvasDisplayModeFilled}`);
 		}
@@ -396,7 +396,7 @@ export function checkForFirstShapeAutoRSB() {
 	const editor = getCurrentProjectEditor();
 	const selectedItem = editor.selectedItem;
 	if (selectedItem?.objType === 'Glyph' || selectedItem?.objType === 'Ligature') {
-		const autoRSB = editor.project.settings.app.autoRightBearingOnFirstShape;
+		const autoRSB = getConfigGroup('app').autoRightBearingOnFirstShape;
 		if (selectedItem.shapes.length === 1 && selectedItem.advanceWidth === 0 && autoRSB > -1) {
 			selectedItem.rightSideBearing = autoRSB;
 		}

--- a/src/formats_io/otf/font_export.js
+++ b/src/formats_io/otf/font_export.js
@@ -1,5 +1,5 @@
 import { FontFlux, initWoff2 } from 'font-flux-js';
-import { getCurrentProject } from '../../app/main.js';
+import { getConfigGroup, getCurrentProject } from '../../app/main.js';
 import { decToHex, parseCharsInputAsHex } from '../../common/character_ids.js';
 import { isUIUpdateDue, pause, resetUIUpdateThrottle, round } from '../../common/functions.js';
 import { closeAllToasts, showError, showToast } from '../../controls/dialogs/dialogs.js';
@@ -130,7 +130,7 @@ export async function ioFont_exportFont(suffix = 'otf', testing = false) {
 	// log(codePointGlyphIndexTable);
 
 	// Add Ligatures
-	let exportLigatures = project.settings.app.exportLigatures;
+	let exportLigatures = getConfigGroup('app').exportLigatures;
 	// log(`exportLigatures: ${exportLigatures}`);
 	if (exportLigatures) {
 		for (let l = 0; l < exportLists.ligatures.length; l++) {
@@ -226,7 +226,7 @@ export async function ioFont_exportFont(suffix = 'otf', testing = false) {
 
 	// Write kern pair data first, before setting GSUB features
 	// This ensures the font's GPOS table is properly initialized
-	if (project.settings.app.exportKerning) {
+	if (getConfigGroup('app').exportKerning) {
 		writeGposKernDataToFont(font, project);
 	}
 
@@ -534,7 +534,7 @@ export function shouldExportItem(item) {
 	if (item.name === '.null') return false;
 
 	if (item.sessionState === 'new') {
-		return !!getCurrentProject().settings.app.exportUneditedItems;
+		return !!getConfigGroup('app').exportUneditedItems;
 	}
 	if (item) return true;
 	return false;
@@ -575,7 +575,7 @@ function populateExportList() {
 	// Add Ligatures
 	const exportLigatures = [];
 	// const ligWithCodePoint;
-	if (project.settings.app.exportLigatures) {
+	if (getConfigGroup('app').exportLigatures) {
 		for (const key of Object.keys(project.ligatures)) {
 			// log(project.ligatures[key]);
 			if (project.ligatures[key].gsub.length > 1) {

--- a/src/formats_io/otf/tables/glyphs.js
+++ b/src/formats_io/otf/tables/glyphs.js
@@ -1,3 +1,4 @@
+import { getConfigGroup } from '../../../app/main';
 import { decToHex } from '../../../common/character_ids';
 import { isControlChar } from '../../../lib/unicode/unicode_blocks';
 import { Glyph } from '../../../project_data/glyph';
@@ -146,7 +147,7 @@ function importOneGlyph(
 
 			if (isNewSlot) {
 				if (isControlChar(unicodeHex) && unicodeHex !== '0x0') {
-					project.settings.app.showNonCharPoints = true;
+					getConfigGroup('app').showNonCharPoints = true;
 				}
 
 				if (!isNaN(Number(unicodeHex))) project.incrementRangeCountFor(Number(unicodeHex));

--- a/src/formats_io/svg_font/svg_font_export.js
+++ b/src/formats_io/svg_font/svg_font_export.js
@@ -1,4 +1,4 @@
-import { getCurrentProject, getGlyphrStudioApp } from '../../app/main.js';
+import { getConfigGroup, getCurrentProject, getGlyphrStudioApp } from '../../app/main.js';
 import { decToHex, hexesToXMLHexes } from '../../common/character_ids.js';
 import { escapeXMLValues, round } from '../../common/functions.js';
 import { showToast } from '../../controls/dialogs/dialogs.js';
@@ -207,7 +207,7 @@ function ioSVG_makeAllGlyphs() {
 		con += ioSVG_makeOneGlyph(glyph.xg, glyph.xc);
 	});
 
-	if (project.settings.app.exportLigatures) {
+	if (getConfigGroup('app').exportLigatures) {
 		con += '\n';
 
 		con += '\t\t\t<!-- Ligatures -->\n';
@@ -279,7 +279,7 @@ function ioSVG_makeOneGlyph(gl, id, tag = 'glyph') {
 function ioSVG_makeAllKernPairs() {
 	// log('ioSVG_makeAllKernPairs', 'start');
 	const project = getCurrentProject();
-	if (!project.settings.app.exportKerning) return '';
+	if (!getConfigGroup('app').exportKerning) return '';
 
 	const kp = project.kerning;
 	let keys = Object.keys(kp);

--- a/src/formats_io/svg_font/svg_font_import.js
+++ b/src/formats_io/svg_font/svg_font_import.js
@@ -1,4 +1,8 @@
-import { getProjectEditorImportTarget, setCurrentProjectEditor } from '../../app/main.js';
+import {
+	getConfigGroup,
+	getProjectEditorImportTarget,
+	setCurrentProjectEditor,
+} from '../../app/main.js';
 import {
 	charToHex,
 	hexesToChars,
@@ -77,7 +81,7 @@ export async function ioSVG_importSVGfont(font, testing = false) {
 				// log(`UNI detected ${glyphName} hex is ${hex}`);
 				if (hex) {
 					uni = [hex];
-					project.settings.app.showNonCharPoints = true;
+					getConfigGroup('app').showNonCharPoints = true;
 				}
 			}
 			// log(`attributes.unicode: |${attributes.unicode}| parsed as ${uni}`);
@@ -108,7 +112,7 @@ export async function ioSVG_importSVGfont(font, testing = false) {
 					// log(newGlyph);
 					finalGlyphs[`glyph-${single}`] = newGlyph;
 					if (getUnicodeName(single).startsWith('U+')) {
-						project.settings.app.showNonCharPoints = true;
+						getConfigGroup('app').showNonCharPoints = true;
 					}
 				} else {
 					// It's a LIGATURE
@@ -415,10 +419,10 @@ function getKernMembersByUnicodeID(ids, chars, arr, limit) {
 						// log(`Comparing idHex: ${idHex} with charHex: ${charHex}`);
 						if (charHex !== false && idHex === charHex) {
 							if (Number(charHex) < limit) arr = arr.concat(charHex);
+						}
 					}
 				}
 			}
-		}
 		}
 	}
 

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,5 +1,5 @@
 import { emailLink } from '../app/app.js';
-import { getCurrentProjectEditor, getGlyphrStudioApp } from '../app/main.js';
+import { getConfigGroup, getCurrentProjectEditor, getGlyphrStudioApp } from '../app/main.js';
 import { addAsChildren, makeElement } from '../common/dom.js';
 import donateKofiSrc from '../common/graphics/donate-kofi.png';
 import donatePaypalSrc from '../common/graphics/donate-paypal.png';
@@ -169,11 +169,9 @@ function makeVersionInfo() {
 
 			<div class="page__card">
 				<h3>This Glyphr Studio Project</h3>
-				<label>Project name:</label> ${editor.project.settings.project.name}<br>
-				<label>Unique project ID:</label> ${editor.project.settings.project.id}<br>
-				<label>Initially created with:</label> Version ${
-					editor.project.settings.project.initialVersion
-				}</span>
+				<label>Project name:</label> ${getConfigGroup('project').name}<br>
+				<label>Unique project ID:</label> ${getConfigGroup('project').id}<br>
+				<label>Initially created with:</label> Version ${getConfigGroup('project').initialVersion}</span>
 			</div>
 
 			<br><br>

--- a/src/pages/global_actions_cards.js
+++ b/src/pages/global_actions_cards.js
@@ -1,4 +1,4 @@
-import { getCurrentProject, getCurrentProjectEditor } from '../app/main.js';
+import { getConfigGroup, getCurrentProject, getCurrentProjectEditor } from '../app/main.js';
 import { decToHex, validateAsHex } from '../common/character_ids.js';
 import { addAsChildren, makeElement } from '../common/dom.js';
 import { remove } from '../common/functions.js';
@@ -626,7 +626,7 @@ export function makeCard_RemoveItems() {
 			action: (workingItem) => {
 				const project = workingItem.parent;
 				if (project) {
-					const unlinkComponentInstances = project.settings.app.unlinkComponentInstances;
+					const unlinkComponentInstances = getConfigGroup('app').unlinkComponentInstances;
 					resolveItemLinks(workingItem, unlinkComponentInstances);
 					if (workingItem.objType === 'Component') {
 						delete project.components[workingItem.id];

--- a/src/pages/overview.js
+++ b/src/pages/overview.js
@@ -1,5 +1,5 @@
 import { emailLink } from '../app/app.js';
-import { getCurrentProject, getCurrentProjectEditor } from '../app/main.js';
+import { getConfigGroup, getCurrentProject, getCurrentProjectEditor } from '../app/main.js';
 import { makeElement } from '../common/dom.js';
 import { countItems } from '../common/functions.js';
 import { showModalDialog } from '../controls/dialogs/dialogs.js';
@@ -52,7 +52,7 @@ export function makePage_Overview() {
 
 	const project = getCurrentProject();
 	const rightArea = content.querySelector('.content-page__right-area');
-	let previewText = project.settings.app.previewText || 'Aa Bb Cc Xx Yy Zz';
+	let previewText = getConfigGroup('app').previewText || 'Aa Bb Cc Xx Yy Zz';
 
 	rightArea.appendChild(
 		makeElement({

--- a/src/pages/settings.js
+++ b/src/pages/settings.js
@@ -1,8 +1,7 @@
-import { getCurrentProject, getCurrentProjectEditor } from '../app/main.js';
+import { getConfigGroup, getCurrentProject, getCurrentProjectEditor } from '../app/main.js';
 import { addAsChildren, makeElement, textToNode } from '../common/dom.js';
 import { showToast } from '../controls/dialogs/dialogs.js';
 import { TabControl } from '../controls/tabs/tab_control.js';
-import { makeDirectCheckbox } from '../panels/cards.js';
 import { makeNavButton, toggleNavDropdown } from '../project_editor/navigator.js';
 import { makeSettingsTabContentApp } from './settings_app.js';
 import settingsMap from './settings_data.js';
@@ -69,10 +68,10 @@ export function makeOneSettingsRow(groupName, propertyName, callback, inputFirst
 	// log(`makeOneSettingsRow`, 'start');
 	// log(`groupName: ${groupName}`);
 	// log(`propertyName: ${propertyName}`);
-	const settings = getCurrentProject().settings;
+	const group = getConfigGroup(groupName);
 	const thisSetting = settingsMap[groupName][propertyName];
 	const settingType = thisSetting?.type;
-	const settingValue = settings[groupName][propertyName];
+	const settingValue = group[propertyName];
 	// log(`thisSetting: ${thisSetting}`);
 	// log(`settingValue: ${settingValue}`);
 
@@ -102,7 +101,7 @@ export function makeOneSettingsRow(groupName, propertyName, callback, inputFirst
 			if (isNaN(newValue)) {
 				showToast(`Could not save value - needs to be a number.`);
 			} else {
-				settings[groupName][propertyName] = newValue;
+				group[propertyName] = newValue;
 			}
 			if (callback) callback();
 		});
@@ -117,15 +116,25 @@ export function makeOneSettingsRow(groupName, propertyName, callback, inputFirst
 		input.addEventListener('change', (event) => {
 			// @ts-expect-error 'property does exist'
 			let newValue = sanitizeValueWithJSON(event.target.value);
-			settings[groupName][propertyName] = newValue;
+			group[propertyName] = newValue;
 			if (callback) callback();
 		});
 	}
 
 	if (settingType === 'Boolean') {
-		input = makeDirectCheckbox(settings[groupName], propertyName, callback);
-		if (propertyName === 'showNonCharPoints') {
-			input.addEventListener('change', () => {
+		input = makeElement({
+			tag: 'input',
+			attributes: { type: 'checkbox' },
+		});
+		// @ts-expect-error 'property does exist'
+		if (settingValue) input.checked = true;
+		input.addEventListener('change', (event) => {
+			// @ts-expect-error 'property does exist'
+			let newValue = event.target.checked;
+			group[propertyName] = !!newValue;
+			if (callback) callback(newValue);
+
+			if (propertyName === 'showNonCharPoints') {
 				const project = getCurrentProject();
 				// log(`Clearing all Character Range Caches`);
 				// log(`\n⮟project.settings.project.characterRanges⮟`);
@@ -134,8 +143,8 @@ export function makeOneSettingsRow(groupName, propertyName, callback, inputFirst
 					range.cachedArray = false;
 				});
 				getCurrentProjectEditor().selectedCharacterRange.cachedArray = false;
-			});
-		}
+			}
+		});
 	} else {
 		type = makeElement({
 			tag: 'pre',

--- a/src/pages/settings_app.js
+++ b/src/pages/settings_app.js
@@ -1,5 +1,5 @@
 import { updateWindowUnloadEvent } from '../app/app';
-import { getGlyphrStudioApp } from '../app/main';
+import { getCurrentProjectEditor, getGlyphrStudioApp } from '../app/main';
 import { addAsChildren, makeElement, textToNode } from '../common/dom';
 import { showToast } from '../controls/dialogs/dialogs';
 import { makeOneSettingsRow } from './settings';
@@ -37,6 +37,23 @@ export function makeSettingsTabContentApp() {
 			onClick: () => {
 				getGlyphrStudioApp().setLocalStorage('autoSaves', '');
 				showToast('Auto-saved backups were deleted for this browser.');
+			},
+		}),
+		textToNode('<span></span>'),
+		textToNode('<label class="settings__label">Reset app settings:</label>'),
+		makeElement({
+			tag: 'info-bubble',
+			content: `Glyphr Studio uses your browser's local storage to keep app-specific settings. This is basically a "factory reset" button.`,
+		}),
+		makeElement({
+			tag: 'fancy-button',
+			attributes: { danger: '', style: 'height: 24px;' },
+			innerHTML: 'Delete',
+			onClick: () => {
+				getGlyphrStudioApp().resetAppSettings();
+				let editor = getCurrentProjectEditor();
+				editor.navigate();
+				showToast('App settings have been reset.');
 			},
 		}),
 		textToNode('<span></span>'),

--- a/src/pages/settings_project.js
+++ b/src/pages/settings_project.js
@@ -1,4 +1,4 @@
-import { getCurrentProject, getCurrentProjectEditor } from '../app/main.js';
+import { getConfigGroup, getCurrentProject, getCurrentProjectEditor } from '../app/main.js';
 import { decToHex, hexesToChars } from '../common/character_ids.js';
 import { addAsChildren, makeElement, textToNode } from '../common/dom.js';
 import { remove } from '../common/functions.js';
@@ -314,7 +314,7 @@ function makeHiddenRangesTable() {
 function removeCharacterRange(range, manageDialogs = true) {
 	const editor = getCurrentProjectEditor();
 	const fallback = areCharacterRangesEqual(range, editor.selectedCharacterRange);
-	const projectRanges = editor.project.settings.project.characterRanges;
+	const projectRanges = getConfigGroup('project').characterRanges;
 	let index = projectRanges.indexOf(range);
 	if (index > -1) {
 		let name = range.name;
@@ -865,7 +865,7 @@ export function addCharacterRangeToCurrentProject(range, successCallback, showNo
 		ranges.push(newRange);
 
 		if (newRange.name.includes('Controls')) {
-			project.settings.app.showNonCharPoints = true;
+			getConfigGroup('app').showNonCharPoints = true;
 			// log(`clearing new range`);
 			newRange.cachedArray = false;
 		}

--- a/src/panels/context_characters.js
+++ b/src/panels/context_characters.js
@@ -1,4 +1,4 @@
-import { getCurrentProject, getCurrentProjectEditor } from '../app/main.js';
+import { getConfigGroup, getCurrentProject, getCurrentProjectEditor } from '../app/main.js';
 import { addAsChildren, makeElement } from '../common/dom.js';
 import { makeFancySlider } from '../controls/fancy-slider/fancy_slider.js';
 import { makeLivePreviewPopOutCard } from '../project_editor/pop_out_window.js';
@@ -26,7 +26,7 @@ export function makePanel_ContextCharacters() {
 		the character you are currently editing.`,
 	});
 
-	const ccOptions = project.settings.app.contextCharacters;
+	const ccOptions = getConfigGroup('app').contextCharacters;
 	let toggleCheckboxLabel = makeSingleLabel('Show&nbsp;context&nbsp;characters&nbsp;&nbsp;');
 	let toggleCheckbox = makeDirectCheckbox(ccOptions, 'showCharacters', () => {
 		getCurrentProjectEditor().autoFitView();

--- a/src/panels/guides.js
+++ b/src/panels/guides.js
@@ -1,4 +1,9 @@
-import { getCurrentProject, getCurrentProjectEditor } from '../app/main.js';
+import {
+	getConfigGroup,
+	getCurrentProject,
+	getCurrentProjectEditor,
+	getGlyphrStudioApp,
+} from '../app/main.js';
 import { makeRandomSaturatedColor, parseColorString, rgbToHex } from '../common/colors.js';
 import { addAsChildren, makeElement } from '../common/dom.js';
 import { round } from '../common/functions.js';
@@ -23,7 +28,7 @@ export function makePanel_Guides() {
 		className: 'panel__card guides-card__view-options',
 		innerHTML: '<h3>View options</h3>',
 	});
-	const guides = getCurrentProject().settings.app.guides;
+	const guides = getConfigGroup('project').guides;
 	const showSystem = guides.systemShowGuides;
 	const showCustom = guides.customShowGuides;
 	const showGrid = guides.gridShow;
@@ -139,7 +144,7 @@ function makeSystemGuideRow(property, title, value = '0000', color) {
 	// Checkbox
 	const viewCheckbox = makeDirectCheckbox(systemGuides, property, (newValue) => {
 		const editor = getCurrentProjectEditor();
-		let shownGuides = editor.project.settings.app.guides.systemGuides;
+		let shownGuides = getConfigGroup('project').guides.systemGuides;
 		if (newValue) {
 			if (!shownGuides.includes(property)) {
 				shownGuides.push(property);
@@ -187,7 +192,7 @@ function makeCustomGuidesCard() {
 		innerHTML: '<h3>Custom guides</h3>',
 	});
 
-	const guides = getCurrentProject().settings.app.guides.custom;
+	const guides = getConfigGroup('project').guides.custom;
 
 	if (guides.length) {
 		guides.forEach((guide, number) => {
@@ -203,9 +208,9 @@ function makeCustomGuidesCard() {
 		innerHTML: 'Add a custom guide',
 	});
 	addGuideButton.addEventListener('click', () => {
-		getCurrentProject().settings.app.guides.custom.push(
-			new Guide({ visible: true, color: makeRandomSaturatedColor() })
-		);
+		getGlyphrStudioApp()
+			.getGroup('project')
+			.guides.custom.push(new Guide({ visible: true, color: makeRandomSaturatedColor() }));
 		refreshGuideChange();
 	});
 
@@ -229,7 +234,7 @@ function makeCustomGuideRow(guide, number) {
 	const deleteButton = makeActionButton({ iconName: 'delete', title: 'Delete guide' });
 	deleteButton.setAttribute('class', 'guide-delete-button');
 	deleteButton.addEventListener('click', () => {
-		const guides = getCurrentProject().settings.app.guides.custom;
+		const guides = getConfigGroup('project').guides.custom;
 		guides.splice(number, 1);
 		refreshGuideChange();
 	});
@@ -257,7 +262,7 @@ function makeCustomGuideRow(guide, number) {
 		angleButton.querySelector('g').setAttribute('fill', rgbString);
 
 		// Update guide
-		const guide = getCurrentProject().settings.app.guides.custom[number];
+		const guide = getConfigGroup('project').guides.custom[number];
 		guide.color = rgbString;
 		getCurrentProjectEditor().editCanvas.redraw('guides custom color change');
 	});
@@ -279,7 +284,7 @@ function makeCustomGuideRow(guide, number) {
 		});
 	}
 	angleButton.addEventListener('click', () => {
-		const guide = getCurrentProject().settings.app.guides.custom[number];
+		const guide = getConfigGroup('project').guides.custom[number];
 		if (guide.angle === 90) {
 			guide.angle = 0;
 			guide.name = guide.name.replace('Horizontal', 'Vertical');
@@ -298,7 +303,7 @@ function makeCustomGuideRow(guide, number) {
 }
 
 function makeGridCard() {
-	const guides = getCurrentProject().settings.app.guides;
+	const guides = getConfigGroup('project').guides;
 	const gridCard = makeElement({
 		className: 'panel__card guides-card__grid',
 		innerHTML: '<h3>Grid</h3>',

--- a/src/panels/item_chooser.js
+++ b/src/panels/item_chooser.js
@@ -1,4 +1,4 @@
-import { getCurrentProject, getCurrentProjectEditor } from '../app/main.js';
+import { getConfigGroup, getCurrentProject, getCurrentProjectEditor } from '../app/main.js';
 import { addAsChildren, makeElement } from '../common/dom.js';
 import { countItems } from '../common/functions.js';
 import { GlyphTile } from '../controls/glyph-tile/glyph_tile.js';
@@ -19,7 +19,7 @@ export function makeAllItemTypeChooserContent(
 	editor = getCurrentProjectEditor()
 ) {
 	// log(`makeAllItemTypeChooserContent`, 'start');
-	// log(`Project Name: ${editor.project.settings.project.name}`);
+	// log(`Project Name: ${getConfigGroup('project').name}`);
 	savedClickHandler = clickHandler;
 	savedRegisterSubscriptions = true;
 
@@ -99,7 +99,7 @@ export function makeSingleItemTypeChooserContent(itemPageName, clickHandler) {
 
 export function makeRangeAndItemTypeChooser(editor = getCurrentProjectEditor(), rangeName = '') {
 	// log(`makeRangeAndItemTypeChooser`, 'start');
-	// log(`Project Name: ${editor.project.settings.project.name}`);
+	// log(`Project Name: ${getConfigGroup('project').name}`);
 
 	let componentCount = countItems(editor.project.components);
 	let ligatureCount = countItems(editor.project.ligatures);
@@ -193,9 +193,9 @@ function makeRangeChooser(editor = getCurrentProjectEditor()) {
 
 function addRangeOptionsToOptionChooser(optionChooser, editor = getCurrentProjectEditor()) {
 	// log(`addRangeOptionsToOptionChooser`, 'start');
-	// log(`Project Name: ${editor.project.settings.project.name}`);
+	// log(`Project Name: ${getConfigGroup('project').name}`);
 
-	let ranges = editor.project.settings.project.characterRanges;
+	let ranges = getConfigGroup('project').characterRanges;
 	let option;
 	ranges.forEach((range) => {
 		if (range.enabled) {
@@ -228,8 +228,8 @@ function addRangeOptionsToOptionChooser(optionChooser, editor = getCurrentProjec
 function makeCharacterChooserTileGrid(editor = getCurrentProjectEditor()) {
 	// log(`makeCharacterChooserTileGrid`, 'start');
 	// console.time('makeCharacterChooserTileGrid');
-	// log(`Project Name: ${editor.project.settings.project.name}`);
-	// log(editor.project.settings.project.characterRanges);
+	// log(`Project Name: ${getConfigGroup('project').name}`);
+	// log(getConfigGroup('project').characterRanges);
 	// log(editor.selectedCharacterRange);
 
 	const isPrimaryProject = editor === getCurrentProjectEditor();
@@ -494,7 +494,7 @@ export function makeOneKernGroupRow(kernID, project = getCurrentProject()) {
 // --------------------------------------------------------------
 
 function getItemsFromPage(itemsArray = [], pageNumber = 0, editor = getCurrentProjectEditor()) {
-	const pageSize = parseInt(editor.project.settings.app.itemChooserPageSize) || 256;
+	const pageSize = parseInt(getConfigGroup('app').itemChooserPageSize) || 256;
 	if (itemsArray.length < pageSize) return itemsArray;
 	const startIndex = pageNumber * pageSize;
 	const endIndex = startIndex + pageSize;
@@ -510,7 +510,7 @@ function makePageControl(area, allItems = [], editor = getCurrentProjectEditor()
 		kerning: makeKernGroupChooserList,
 	};
 
-	const pageSize = parseInt(editor.project.settings.app.itemChooserPageSize) || 256;
+	const pageSize = parseInt(getConfigGroup('app').itemChooserPageSize) || 256;
 	const currentPage = editor.chooserPage[area];
 	const totalPages = Math.ceil(allItems.length / pageSize);
 	const previousButton = makeElement({

--- a/src/panels/quality_checks.js
+++ b/src/panels/quality_checks.js
@@ -1,4 +1,4 @@
-import { getCurrentProjectEditor } from '../app/main.js';
+import { getConfigGroup, getCurrentProjectEditor } from '../app/main.js';
 import { addAsChildren, makeElement } from '../common/dom.js';
 import settingsData from '../pages/settings_data.js';
 import { enabledQualityChecks, runQualityChecksForItem } from '../project_editor/quality_checks.js';
@@ -64,13 +64,13 @@ function makeCard_PointsAndHandles() {
 		const input = makeElement({
 			tag: 'input-number',
 			attributes: {
-				value: editor.project.settings.app[checkName],
+				value: getConfigGroup('app')[checkName],
 			},
 		});
 
 		input.addEventListener('change', (event) => {
 			// @ts-expect-error 'property does exist'
-			editor.project.settings.app[checkName] = parseInt(event.target.value);
+			getConfigGroup('app')[checkName] = parseInt(event.target.value);
 			runQualityChecksForItem(editor.selectedItem);
 			editor.publish('qualityChecks', 'update');
 		});

--- a/src/project_data/character_range.js
+++ b/src/project_data/character_range.js
@@ -1,4 +1,4 @@
-import { getCurrentProject } from '../app/main.js';
+import { getConfigGroup } from '../app/main.js';
 import { decToHex } from '../common/character_ids.js';
 import { isControlChar } from '../lib/unicode/unicode_blocks.js';
 
@@ -80,7 +80,7 @@ export class CharacterRange {
 	 */
 	*generator() {
 		// log(`CharacterRange.generator`, 'start');
-		const showNonCharPoints = getCurrentProject().settings.app.showNonCharPoints;
+		const showNonCharPoints = getConfigGroup('app').showNonCharPoints;
 		// log(`showNonCharPoints: ${showNonCharPoints}`);
 		if (this.begin <= 0x21 && (this.end === 0x7e || this.end === 0x7f)) {
 			let basicLatinIndex = 0;

--- a/src/project_data/glyphr_studio_project.js
+++ b/src/project_data/glyphr_studio_project.js
@@ -1,4 +1,4 @@
-import { getCurrentProjectEditor, getGlyphrStudioApp } from '../app/main.js';
+import { getConfigGroup, getCurrentProjectEditor, getGlyphrStudioApp } from '../app/main.js';
 import { charsToHexArray, validateAsHex } from '../common/character_ids.js';
 import { clone, remove, round, trim } from '../common/functions.js';
 import { TextBlockOptions } from '../display_canvas/text_block_options.js';
@@ -43,29 +43,6 @@ export class GlyphrStudioProject {
 				// and the File menu preview default to that same format.
 				exportFormat: 'otf',
 				characterRanges: [],
-			},
-			app: {
-				stopPageNavigation: true,
-				formatSaveFile: false,
-				saveLivePreviews: true,
-				autoSave: true,
-				savePreferences: false,
-				unlinkComponentInstances: true,
-				directlyDragCurves: true,
-				canvasDisplayModeFilled: true,
-				showNonCharPoints: false,
-				itemChooserPageSize: 256,
-				previewText: false,
-				exportLigatures: true,
-				exportKerning: true,
-				exportUneditedItems: true,
-				moveShapesOnSVGDragDrop: false,
-				autoSideBearingsOnSVGDragDrop: 50,
-				autoRightBearingOnFirstShape: 50,
-				highlightPointsNearPoints: 2,
-				highlightPointsNearHandles: 2,
-				highlightPointsNearXZero: 2,
-				highlightPointsNearYZero: 2,
 				guides: {
 					drawGuidesOnTop: false,
 					systemShowGuides: true,
@@ -81,13 +58,6 @@ export class GlyphrStudioProject {
 					gridDivisions: 10,
 					gridSnap: false,
 				},
-				contextCharacters: {
-					showCharacters: false,
-					characterTransparency: 20,
-					showGuides: true,
-					guidesTransparency: 70,
-				},
-				livePreviews: [],
 			},
 			font: {
 				family: 'My Font',
@@ -153,11 +123,13 @@ export class GlyphrStudioProject {
 		// Guides
 		const newGuides = newProject?.settings?.app?.guides;
 		if (newGuides?.systemGuides) {
-			this.settings.app.guides.systemGuides = clone(newGuides.systemGuides);
+			this.settings.project.guides.systemGuides = clone(newGuides.systemGuides);
 		}
 		if (newGuides?.custom) {
-			this.settings.app.guides.custom = [];
-			newGuides.custom.forEach((guide) => this.settings.app.guides.custom.push(new Guide(guide)));
+			this.settings.project.guides.custom = [];
+			newGuides.custom.forEach((guide) =>
+				this.settings.project.guides.custom.push(new Guide(guide))
+			);
 		}
 
 		// Character Ranges
@@ -180,12 +152,12 @@ export class GlyphrStudioProject {
 		// Validate descent
 		this.settings.font.descent = -1 * Math.abs(this.settings.font.descent);
 
-		// Live Previews
-		const newPreviews = newProject?.settings?.app?.livePreviews;
-		if (newPreviews) {
-			this.settings.app.livePreviews = [];
-			this.settings.app.livePreviews = newPreviews.map((option) => new TextBlockOptions(option));
-		}
+		// // Live Previews
+		// const newPreviews = newProject?.settings?.app?.livePreviews;
+		// if (newPreviews) {
+		// 	this.settings.app.livePreviews = [];
+		// 	this.settings.app.livePreviews = newPreviews.map((option) => new TextBlockOptions(option));
+		// }
 
 		// log('finished merging settings - result:');
 		// log(this.settings);
@@ -248,16 +220,16 @@ export class GlyphrStudioProject {
 			savedProject.settings.project.characterRanges.push(range.save());
 		});
 
-		// Overwriting livePreviews with .save() version
-		savedProject.settings.app.livePreviews = [];
-		this.settings.app.livePreviews.forEach((preview) => {
-			savedProject.settings.app.livePreviews.push(preview.save());
-		});
+		// // Overwriting livePreviews with .save() version
+		// savedProject.settings.app.livePreviews = [];
+		// this.settings.app.livePreviews.forEach((preview) => {
+		// 	savedProject.settings.app.livePreviews.push(preview.save());
+		// });
 
 		// Overwriting guides with .save() version
-		savedProject.settings.app.guides.custom = [];
-		this.settings.app.guides.custom.forEach((guide) => {
-			savedProject.settings.app.guides.custom.push(guide.save());
+		savedProject.settings.project.guides.custom = [];
+		this.settings.project.guides.custom.forEach((guide) => {
+			savedProject.settings.project.guides.custom.push(guide.save());
 		});
 
 		/**
@@ -456,7 +428,7 @@ export class GlyphrStudioProject {
 		newParentRange.count = 1;
 		if (createAsHidden) newParentRange.enabled = false;
 		projectRanges.push(newParentRange);
-		if (unicodeNonCharPointNames[id] && id !== 0) this.settings.app.showNonCharPoints = true;
+		if (unicodeNonCharPointNames[id] && id !== 0) getConfigGroup('app').showNonCharPoints = true;
 		// log(`createRangeForHex`, 'end');
 	}
 

--- a/src/project_data/tests/character_range.test.js
+++ b/src/project_data/tests/character_range.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { CharacterRange, basicLatinOrder } from '../character_range.js';
+import { getGlyphrStudioApp } from '../../app/main.js';
 
 // --------------------------------------------------------------
 // CHECKLIST
@@ -17,6 +18,8 @@ import { CharacterRange, basicLatinOrder } from '../character_range.js';
 */
 
 describe('CharacterRange', () => {
+	// Needs to be initialized
+	let _app = getGlyphrStudioApp();
 	// Test the constructor
 	it('constructor', () => {
 		const range = new CharacterRange({ begin: 65, end: 90, name: 'Basic Latin' });

--- a/src/project_data/tests/glyphr_studio_project.test.js
+++ b/src/project_data/tests/glyphr_studio_project.test.js
@@ -37,8 +37,7 @@ describe('GlyphrStudioProject Tests', () => {
 		const project = new GlyphrStudioProject();
 		expect(project.settings.project.name).toBe('My Font');
 		expect(project.settings.project.characterRanges[0].name).toEqual('Basic Latin');
-		expect(project.settings.app.guides.custom).toEqual([]);
-		expect(project.settings.app.livePreviews).toEqual([]);
+		expect(project.settings.project.guides.custom).toEqual([]);
 		expect(project.settings.font.family).toBe('My Font');
 	});
 
@@ -56,8 +55,7 @@ describe('GlyphrStudioProject Tests', () => {
 				name: 'Basic Latin',
 			},
 		]);
-		expect(savedProject.settings.app.guides.custom).toEqual([]);
-		expect(savedProject.settings.app.livePreviews).toEqual([]);
+		expect(savedProject.settings.project.guides.custom).toEqual([]);
 		expect(savedProject.settings.font.family).toBe('My Font');
 	});
 

--- a/src/project_editor/history.js
+++ b/src/project_editor/history.js
@@ -1,4 +1,4 @@
-import { getCurrentProjectEditor, getGlyphrStudioApp } from '../app/main.js';
+import { getConfigGroup, getCurrentProjectEditor, getGlyphrStudioApp } from '../app/main.js';
 import { showToast } from '../controls/dialogs/dialogs.js';
 import { refreshPanel } from '../panels/panels.js';
 import { Glyph } from '../project_data/glyph.js';
@@ -151,7 +151,7 @@ export class History {
 		const redoButton = document.querySelector('#actionButtonRedo');
 		if (redoButton) redoButton.setAttribute('disabled', 'disabled');
 
-		if (editor.project.settings.app.autoSave) {
+		if (getConfigGroup('app').autoSave) {
 			const app = getGlyphrStudioApp();
 			if (app.settings.dev.mode) {
 				if (app.settings.dev.autoSave) app.addAutoSaveState();

--- a/src/project_editor/import_project.js
+++ b/src/project_editor/import_project.js
@@ -85,7 +85,7 @@ export function importGlyphrProjectFromText(importedProject) {
  */
 function migrate__v2_10_to_v2_11(project) {
 	project.settings.project.guides = project.settings.app.guides;
-	delete project.settings.app.guides;
+	delete project.settings.app;
 
 	return project;
 }

--- a/src/project_editor/import_project.js
+++ b/src/project_editor/import_project.js
@@ -37,6 +37,11 @@ export function importGlyphrProjectFromText(importedProject) {
 		importedProject = migrate__v2_0_0_to_v2_5_0(importedProject);
 	}
 
+	// Apply v2.11 setting API changes
+	if (version.major === 2 && version.minor < 11) {
+		importedProject = migrate__v2_10_to_v2_11(importedProject);
+	}
+
 	// Update the version
 	const app = getGlyphrStudioApp();
 	importedProject.settings.project.latestVersion = app.version;
@@ -68,6 +73,21 @@ export function importGlyphrProjectFromText(importedProject) {
 
 	// log('importGlyphrProjectFromText', 'end');
 	return newProject;
+}
+
+// --------------------------------------------------------------
+// Migrate v2.10 to v2.11
+// --------------------------------------------------------------
+/**
+ * v2.11 introduced separation of program (app) and project settings
+ * @param {GlyphrStudioProject} project - Old project data
+ * @returns {GlyphrStudioProject} - Updated project data
+ */
+function migrate__v2_10_to_v2_11(project) {
+	project.settings.project.guides = project.settings.app.guides;
+	delete project.settings.app.guides;
+
+	return project;
 }
 
 // --------------------------------------------------------------

--- a/src/project_editor/import_project.js
+++ b/src/project_editor/import_project.js
@@ -48,7 +48,7 @@ export function importGlyphrProjectFromText(importedProject) {
 	const newProject = new GlyphrStudioProject(importedProject);
 
 	// Pull system guide visibility from project
-	const projectSystemGuides = newProject?.settings?.app?.guides?.systemGuides;
+	const projectSystemGuides = newProject?.settings?.project?.guides?.systemGuides;
 	if (projectSystemGuides) {
 		// log(`\n⮟projectSystemGuides⮟`);
 		// log(projectSystemGuides);
@@ -173,9 +173,8 @@ function migrate__v1_13_2_to_v2_0_0(oldProject) {
 	});
 
 	// Metadata
-	const newPreferences = newProject.settings.app;
 	const newRanges = newProject.settings.project.characterRanges;
-	const newGuides = newProject.settings.app.guides;
+	const newGuides = newProject.settings.project.guides;
 	const newFont = newProject.settings.font;
 	const oldSettings = oldProject.projectsettings;
 	const oldRanges = oldProject.projectsettings.glyphrange;
@@ -199,12 +198,12 @@ function migrate__v1_13_2_to_v2_0_0(oldProject) {
 	if (oldRanges.latinextendedb) newRanges.push(unicodeRanges.latinExtendedB);
 	if (oldRanges.custom.length) oldRanges.custom.forEach((range) => newRanges.push(range));
 
-	// Preferences
+	// Preferences (No longer project-defined)
 	// newPreferences.showNonCharPoints = oldSettings.glyphrange.filternoncharpoints || true;
-	newPreferences.stopPageNavigation = oldSettings.stoppagenavigation || true;
-	newPreferences.formatSaveFile = oldSettings.formatsavefile || true;
-	newPreferences.contextCharacters.showGuides = oldSettings.showcontextglyphguides || true;
-	newPreferences.contextCharacters.transparency = oldColors.contextglyphtransparency || 90;
+	// newPreferences.stopPageNavigation = oldSettings.stoppagenavigation || true;
+	// newPreferences.formatSaveFile = oldSettings.formatsavefile || true;
+	// newPreferences.contextCharacters.showGuides = oldSettings.showcontextglyphguides || true;
+	// newPreferences.contextCharacters.transparency = oldColors.contextglyphtransparency || 90;
 
 	// Guides
 	newGuides.systemTransparency = oldColors.systemguidetransparency || 70;

--- a/src/project_editor/project_editor.js
+++ b/src/project_editor/project_editor.js
@@ -1,3 +1,4 @@
+import { getConfigGroup } from '../app/main.js';
 import { decToHex } from '../common/character_ids.js';
 import { clone, getFirstID, json, round } from '../common/functions.js';
 import { showToast } from '../controls/dialogs/dialogs.js';
@@ -602,7 +603,7 @@ export class ProjectEditor {
 		// log(`itemPageName: ${itemPageName}`);
 
 		let id;
-		const unlinkComponentInstances = this.project.settings.app.unlinkComponentInstances;
+		const unlinkComponentInstances = getConfigGroup('app').unlinkComponentInstances;
 
 		if (itemPageName === 'Characters') {
 			// log(`deleting selectedGlyphID: ${this.selectedGlyphID}`);
@@ -886,7 +887,7 @@ export class ProjectEditor {
 			emWidth += kernGroupDisplayWidth(this.selectedItem);
 			emLeftOffset = kernGroupSideMaxWidth(this.selectedItem.leftGroup);
 			emLeftOffset -= this.selectedItem.value;
-		} else if (this.project.settings.app.contextCharacters.showCharacters) {
+		} else if (getConfigGroup('app').contextCharacters.showCharacters) {
 			// Context Characters
 			let ctxChars = this.selectedItem.contextCharacters;
 			// log(`ctxChars: ${ctxChars}`);
@@ -1025,7 +1026,7 @@ export class ProjectEditor {
 		) {
 			this._livePreviews = [];
 			if (this.project?.settings?.app?.livePreviews.length) {
-				this._livePreviews = this.project.settings.app.livePreviews.map(
+				this._livePreviews = getConfigGroup('app').livePreviews.map(
 					(preview) => new TextBlockOptions(preview)
 				);
 			}
@@ -1075,23 +1076,23 @@ export class ProjectEditor {
 	async saveProjectFile(saveAsCopy = false) {
 		// log(`ProjectEditor.saveProjectFile`, 'start');
 
-		// log('' + this.project.settings.app.formatSaveFile);
+		// log('' + getConfigGroup('app').formatSaveFile);
 
 		let saveData = this.project.save();
 
 		const defaultValues = new GlyphrStudioProject({});
 		saveData = removeDefaultValues(saveData, defaultValues, 'settings');
 
-		if (this.project.settings.app.saveLivePreviews) {
-			saveData.settings.app.livePreviews = [];
-			this.livePreviews.forEach((preview) => {
-				saveData.settings.app.livePreviews.push(preview.save());
-			});
-		} else {
-			delete saveData.settings.app.livePreviews;
-		}
+		// if (this.project.settings.app.saveLivePreviews) {
+		// 	saveData.settings.app.livePreviews = [];
+		// 	this.livePreviews.forEach((preview) => {
+		// 		saveData.settings.app.livePreviews.push(preview.save());
+		// 	});
+		// } else {
+		// 	delete saveData.settings.app.livePreviews;
+		// }
 
-		if (this.project.settings.app.formatSaveFile) saveData = json(saveData);
+		if (getConfigGroup('app').formatSaveFile) saveData = json(saveData);
 		else saveData = JSON.stringify(saveData);
 
 		// log('saveProjectFile - \n'+saveData);

--- a/src/project_editor/quality_checks.js
+++ b/src/project_editor/quality_checks.js
@@ -1,4 +1,4 @@
-import { getCurrentProject } from '../app/main';
+import { getConfigGroup, getCurrentProject } from '../app/main';
 import { calculateLength, clone, valuesAreClose } from '../common/functions';
 
 export const enabledQualityChecks = {
@@ -24,7 +24,7 @@ export function runQualityChecksForItem(item) {
 	}
 
 	const project = getCurrentProject();
-	const psa = project.settings.app;
+	const psa = getConfigGroup('app');
 
 	let pointsNearPoints = [];
 	let pointsNearHandles = [];


### PR DESCRIPTION
This PR focuses on separating what should be program-specific configuration from the project-specific. Everything under the `[project].settings.app` key has been transferred to the root `GlyphrStudioApp` instead, save for the exception of guides, which should stay tied to projects.

The new settings location is wrapped in a proxy that automatically saves any changes to persistent storage after a brief debounce, so configs are always kept around, unless the user decides to reset them with the button added alongside the existing autosave clear.

This did mean that quite a few files had to updated to fit the new paths, but those usages are now under a `getConfigGroup` option so ideally such breaking changes shouldn't be so breaking in the future

I did add a small migration check for moving the `settings.app.guides` to `settings.project.guides` instead and put down 2.11 as the target "new" version, so might revise that if that isn't the version this gets put out under